### PR TITLE
hotfix for linux and windows builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,5 @@ make ausführen:
 ```shell
 cmake --build .
 ```
-Die Executable landet nicht in '/omniview/build/', sondern in '/omniview/build/debug/'.
-Sie muss momentan nach '/omniview/build/' verschoben werden, damit die Pfade stimmen.
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,7 +128,18 @@ int main() {
   std::string addpath = "";
 
   configpath = "../../config/config.json";
-  addpath = "../";
+  addpath = "";
+  if (std::filesystem::exists("../config/config.json")) {
+    configpath = "../config/config.json";
+    fmt::println("linux\n\r");
+  } else if (std::filesystem::exists("../../config/config.json")) {
+    configpath = "../../config/config.json";
+    addpath = "../";
+    fmt::println("windows\n\r");
+  } else {
+    // close programm and with a message, no configfile found
+    return 1; // Rückgabewert 1 signalisiert einen Fehler
+  }
   config = load_json_file(configpath);
 
   std::vector<std::string> availableLanguages = getAvailableLanguages(


### PR DESCRIPTION
Actual build does not work when started from within /build/, only from /build/debug/
this fixes it.