### PR TITLE
added legend changes - colour should be replaced

### DIFF
--- a/src/menuscpp/Style.cpp
+++ b/src/menuscpp/Style.cpp
@@ -4,6 +4,7 @@
 #include <../nlohmann/json.hpp>
 #include <../nlohmann/json_fwd.hpp>*/
 #include <imgui.h>
+#include <implot.h>
 
 //#include "../menushpp/Style.hpp"
 
@@ -115,19 +116,35 @@ inline void SetupImGuiStyle(bool bStyleDark_, float alpha_) {
     }
   }
 }
-} // namespace ImGui
+} // namespace Style
 
 void SetMainWindowStyle() {
+
   ImGuiStyle &style = ImGui::GetStyle();
 
-  style.Colors[ImGuiCol_Text] = { 0.0f, 0.0f, 0.0f, 1.0f };
-  style.Colors[ImGuiCol_WindowBg] = { 1.0f, 1.0f, 0.93f, 1.0f };
-  style.Colors[ImGuiCol_Border] = { 0.14f, 0.15f, 0.17f, 1.0f };
-  style.Colors[ImGuiCol_FrameBg] = { 1.0f, 1.0f, 1.0f, 1.0f };
-  style.Colors[ImGuiCol_FrameBgHovered] = { 1.0f, 1.0f, 1.0f, 1.0f };
-  style.Colors[ImGuiCol_FrameBgActive] = { 1.0f, 1.0f, 1.0f, 1.0f };
+  style.Colors[ImGuiCol_Text] =
+      ImVec4(1 / 255.0f, 1 / 255.0f, 1 / 255.0f, 100 / 100.0f);
+  style.Colors[ImGuiCol_WindowBg] =
+      ImVec4(255 / 255.0f, 255 / 255.0f, 255 / 255.0f, 100 / 100.0f);
+  style.Colors[ImGuiCol_Border] =
+      ImVec4(37 / 255.0f, 40 / 255.0f, 43 / 255.0f, 100 / 100.0f);
+  style.Colors[ImGuiCol_FrameBg] =
+      ImVec4(255 / 255.0f, 255 / 255.0f, 255 / 255.0f, 100 / 100.0f);
+  style.Colors[ImGuiCol_FrameBgHovered] =
+      ImVec4(255 / 255.0f, 255 / 255.0f, 255 / 255.0f, 100 / 100.0f);
+  style.Colors[ImGuiCol_FrameBgActive] =
+      ImVec4(255 / 255.0f, 255 / 255.0f, 255 / 255.0f, 100 / 100.0f);
 
-  // colors when hovering and clicking the axes
-  style.Colors[ImGuiCol_ButtonHovered] = { 0.94f, 0.94f, 0.94f, 1.0f };
-  style.Colors[ImGuiCol_ButtonActive] = { 0.94f, 0.94f, 0.94f, 1.0f };
+  // Die Farben bei Hovern und klicken der Achsen
+  style.Colors[ImGuiCol_ButtonHovered] =
+      ImVec4(240 / 255.0f, 240 / 255.0f, 240 / 255.0f, 100 / 100.0f);
+  style.Colors[ImGuiCol_ButtonActive] =
+      ImVec4(240 / 255.0f, 240 / 255.0f, 240 / 255.0f, 100 / 100.0f);
+}
+
+void SetImPlotLegendProperties() {
+  // Legenden-Hintergrundfarbe ändern
+  ImPlotStyle &plotStyle = ImPlot::GetStyle();
+  plotStyle.Colors[ImPlotCol_LegendBg] =
+      ImVec4(0.5f, 0.5f, 0.5f, 1.0f);
 }

--- a/src/menushpp/Style.hpp
+++ b/src/menushpp/Style.hpp
@@ -3,8 +3,10 @@
 
 namespace Style {
 inline void SetupImGuiStyle(bool bStyleDark_, float alpha_);
-} // namespace ImGui
+} // namespace Style
 
-void SetMainWindowStyle(); 
+void SetMainWindowStyle();
 
-#endif 
+void SetImPlotLegendProperties();
+
+#endif


### PR DESCRIPTION
I have added style changes for the legend. However, due to the color alteration, the labels of the individual scopes are hardly readable. Therefore, I have temporarily made them white. The color can still be changed.
Furthermore, I have changed the location of the legend. It is now positioned in the top right corner, reducing the risk of covering parts of the plot.

added to `Style.cpp`: 

```
void SetImPlotLegendProperties() {
  // Legenden-Hintergrundfarbe ändern
  ImPlotStyle &plotStyle = ImPlot::GetStyle();
  plotStyle.Colors[ImPlotCol_LegendBg] =
      ImVec4(0.5f, 0.5f, 0.5f, 1.0f); // Dunkelgrau
}

```

and to `Style.hpp`: 
`void SetImPlotLegendProperties();`

and this to main: 

```
    SetImPlotLegendProperties();

    addPlots("Recording the data", captureData,
             [&sampler, &xmax_paused](auto /*x_min*/, auto x_max) {
               if (!flagPaused) {
                 ImPlot::SetupAxes("x [Data points]", "y [ADC Value]",
                                   ImPlotAxisFlags_AutoFit,
                                   ImPlotAxisFlags_AutoFit);
                 ImPlot::SetupAxisLimits(ImAxis_X1, x_max - 7500, x_max + 7500,
                                         ImGuiCond_Always);
               } else {
                 xmax_paused = x_max;
                 ImPlot::SetupAxes("x [Seconds]", "y [Volts]");
                 // x and y axes ranges: [0, 10], [-10, 200]
                 ImPlot::SetupAxesLimits(0, 10, -10, 200);
                 // make specific values/ticks on Y-axis
                 ImPlot::SetupAxisTicks(ImAxis_Y1, -10, 200, 22, nullptr, true);
                 ImPlot::SetupLegend(ImPlotLocation_NorthEast);
               }
             });

    ImGui::EndChild();
```