### PR TITLE
saving process and progress bar

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
         include:
           - os: windows-latest
             triplet: x64-windows
-          - os: ubuntu-latest
+          - os: ubuntu-23.04 
             triplet: x64-linux
 
     steps:
@@ -89,7 +89,7 @@ jobs:
             languages/Deutsch.json
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-23.04 
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
             triplet: x64-windows
           - os: ubuntu-latest
             compiler: gcc
-            gcc: 14
+            gcc: 13
             triplet: x64-linux
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
             triplet: x64-windows
           - os: ubuntu-latest
             compiler: gcc
-            gcc: 13
+            gcc: 14
             triplet: x64-linux
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,9 @@ jobs:
         include:
           - os: windows-latest
             triplet: x64-windows
-          - os: ubuntu-23.04 
+          - os: ubuntu-latest
+            compiler: gcc
+            gcc: 13
             triplet: x64-linux
 
     steps:
@@ -89,7 +91,7 @@ jobs:
             languages/Deutsch.json
 
   release:
-    runs-on: ubuntu-23.04 
+    runs-on: ubuntu-latest 
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,4 +67,4 @@ target_include_directories(OmniView PUBLIC ${LIBUSB_INCLUDE_DIRS})
 target_link_libraries(OmniView PUBLIC ${LIBUSB_LIBRARIES})
 
 target_compile_definitions(OmniView PUBLIC BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT)
-target_compile_features(OmniView PUBLIC cxx_std_20)
+target_compile_features(OmniView PUBLIC cxx_std_23)

--- a/src/generateTrainingData.cpp
+++ b/src/generateTrainingData.cpp
@@ -100,7 +100,7 @@ void generateTrainingData(
 
     static std::string Measurement;
     // one extra space for '\0' character
-    static char VIN[18];
+    static char VIN[19];
     static std::string Mileage;
     static std::vector<double> file_measuring_vals; // measurement values
     static bool grayFields = false;
@@ -236,8 +236,7 @@ void generateTrainingData(
       s += data->EventChar;
       // strlen is updated when entered char passes the filter
       size_t indx = strlen(VIN);
-
-      if (indx < 17)
+      if (indx < 18)
         return !std::regex_match(
             s, chars_regex); // return 0 as passed for matched chars
       return 1;              // discard exceeding chars

--- a/src/generateTrainingData.cpp
+++ b/src/generateTrainingData.cpp
@@ -117,31 +117,31 @@ void generateTrainingData(
       if (!readfile.is_open())
         fmt::println("Failed to open file {}", filename);
       else {
-        // first and second lines of file
-        std::string first_line, second_line;
-        for (size_t i = 0; !readfile.eof(); i++) {
-          if (i == 0) {
-            std::getline(readfile, first_line);
-            first_line.pop_back(); // remove ending new line
-            std::stringstream ss(first_line);
-            // extract input fields data from the first line
-            for (size_t j = 0; j < fieldsSize; j++) {
-              std::string substr;
-              std::getline(ss, substr, ',');
-              FieldsData[j] = substr;
-            }
-          } else if (i == 1)
-            std::getline(readfile, second_line); // device ID
-          else {
-            // read measuring values into the vector
-            constexpr size_t bigNumber{10'000'000};
-            readfile.ignore(bigNumber, ',');
-            double value{};
-            readfile >> value;
-            file_measuring_vals.emplace_back(value);
-            // at the last loop, the last number is picked and loop goes on
-            // vector pushes value before eof is reached
-          }
+        // first, second and third lines of file
+        std::string first_line, second_line, third_line;
+        std::getline(readfile, first_line);
+        first_line.pop_back(); // remove ending new line
+        std::stringstream ss(first_line);
+        // extract input fields data from the first line
+        for (size_t j = 0; j < fieldsSize; j++) {
+          std::string substr;
+          std::getline(ss, substr, ',');
+          FieldsData[j] = substr;
+        }
+        std::getline(readfile, second_line); // device ID
+        second_line.pop_back();
+        std::getline(readfile, third_line); // samplying rate
+        third_line.pop_back();
+        while (!readfile.eof()) {
+          // read measuring values into the vector
+          double value{};
+          readfile >> value;
+          file_measuring_vals.emplace_back(value);
+          static constexpr size_t bigNumber{10'000'000};
+          readfile.ignore(bigNumber, ' '); // two spaces between elements
+          readfile.ignore(bigNumber, ' ');
+          // at the last loop, the last number is picked, loop
+          // goes on and vector pushes value before eof is reached
         }
         // pop the extra last element
         file_measuring_vals.pop_back();

--- a/src/languages.hpp
+++ b/src/languages.hpp
@@ -78,7 +78,8 @@ enum class Key {
   German,
   Ready,
   FontSize,
-  SettingsText
+  SettingsText,
+  saving
 };
 
 inline const std::map<Key, const char *> englishLan{
@@ -155,7 +156,8 @@ inline const std::map<Key, const char *> englishLan{
     {Key::German, "German"},
     {Key::Ready, "Ready"},
     {Key::FontSize, "Fontsize"},
-    {Key::SettingsText, "Set your personal settings for the software"}};
+    {Key::SettingsText, "Set your personal settings for the software"},
+    {Key::saving, "saving ..."}};
 
 
 inline const std::map<Key, const char *> germanLan{
@@ -233,7 +235,8 @@ inline const std::map<Key, const char *> germanLan{
     {Key::German, "Deutsch"},
     {Key::Ready, "Bereit"},
     {Key::FontSize, "Schriftgröße"},
-    {Key::SettingsText, "Legen sie hier ihre persönlichen Einstellungen fest"}};
+    {Key::SettingsText, "Legen sie hier ihre persönlichen Einstellungen fest"},
+    {Key::saving, "sparen ..."}};
 
 inline auto appLanguage = englishLan;
 #endif

--- a/src/languages.hpp
+++ b/src/languages.hpp
@@ -79,7 +79,7 @@ enum class Key {
   Ready,
   FontSize,
   SettingsText,
-  saving
+  Saving
 };
 
 inline const std::map<Key, const char *> englishLan{
@@ -157,7 +157,7 @@ inline const std::map<Key, const char *> englishLan{
     {Key::Ready, "Ready"},
     {Key::FontSize, "Fontsize"},
     {Key::SettingsText, "Set your personal settings for the software"},
-    {Key::saving, "saving ..."}};
+    {Key::Saving, "saving ..."}};
 
 
 inline const std::map<Key, const char *> germanLan{
@@ -236,7 +236,7 @@ inline const std::map<Key, const char *> germanLan{
     {Key::Ready, "Bereit"},
     {Key::FontSize, "Schriftgröße"},
     {Key::SettingsText, "Legen sie hier ihre persönlichen Einstellungen fest"},
-    {Key::saving, "sparen ..."}};
+    {Key::Saving, "speichern ..."}};
 
 inline auto appLanguage = englishLan;
 #endif

--- a/src/look_up_saves.hpp
+++ b/src/look_up_saves.hpp
@@ -11,7 +11,7 @@ namespace fs = std::filesystem;
 inline std::string getSubdirectoriesInFolder(nlohmann::json language,
                                       fs::path const &saves_folder_path,
                                       char scantype[255] = 0,
-                                      char inputvin[18] = 0,
+                                      char inputvin[19] = 0,
                                       char mileage[10] = 0) {
   bool isTxtInptFieldsEmpty = false;
   if (scantype != 0 && inputvin != 0 && mileage != 0)
@@ -44,17 +44,16 @@ inline std::string getSubdirectoriesInFolder(nlohmann::json language,
       ImGui::Combo(appLanguage[Key::Known_Car], &selectedOption, vins,
                    static_cast<int>(subdirectories.size()));
 
-      ImGui::InputText(appLanguage[Key::Measurement], scantype, IM_ARRAYSIZE(scantype));
-
+      ImGui::InputText(appLanguage[Key::Measurement], scantype, 255);
       if (selectedOption == 0) {
-        ImGui::InputText("Fin/Vin", inputvin, IM_ARRAYSIZE(inputvin),
+        ImGui::InputText("Fin/Vin", inputvin, 19,
                          ImGuiInputTextFlags_CharsUppercase |
                              ImGuiInputTextFlags_CharsNoBlank |
                              ImGuiInputTextFlags_None);
         selectedFolder = inputvin;
       }
 
-      ImGui::InputText(appLanguage[Key::Mileage], mileage, IM_ARRAYSIZE(mileage));
+      ImGui::InputText(appLanguage[Key::Mileage], mileage, 10);
 
       // Using vins (char* array) with ImGui
       }else {
@@ -62,7 +61,7 @@ inline std::string getSubdirectoriesInFolder(nlohmann::json language,
                    static_cast<int>(subdirectories.size()));
 
       if (selectedOption == 0) {
-        ImGui::InputText("Fin/Vin", inputvin, IM_ARRAYSIZE(inputvin));
+        ImGui::InputText("Fin/Vin", inputvin, 19);
         selectedFolder = inputvin;
       }
       static char VIN[18];
@@ -71,8 +70,8 @@ inline std::string getSubdirectoriesInFolder(nlohmann::json language,
       ImGui::Separator();
       ImGui::Text(appLanguage[Key::Additional_Information]);
       ImGui::NewLine();
-      ImGui::InputText(appLanguage[Key::Measurement], scantype, IM_ARRAYSIZE(scantype));
-      ImGui::InputText(appLanguage[Key::Mileage], mileage, IM_ARRAYSIZE(mileage));
+      ImGui::InputText(appLanguage[Key::Measurement], scantype, 255);
+      ImGui::InputText(appLanguage[Key::Mileage], mileage, 10);
     }
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,6 @@ int main() {
   double xmax_paused{0};
   bool open_settings = false;
   bool open_generate_training_data = false;
-  bool upload_success = false;
   static bool flagPaused = true;
   bool flagDataNotSaved = true;
   bool Development = false;
@@ -173,7 +172,7 @@ int main() {
     if (ImGui::BeginPopupModal(titles[title].c_str(), nullptr,
                                ImGuiWindowFlags_AlwaysAutoResize)) {
       ImGui::SetItemDefaultFocus();
-      popup_settings(config, language, configpath, title);
+      popup_settings(config, configpath, title);
       ImGui::EndPopup();
     }
     // Generate training data popup

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,14 +24,11 @@ int main() {
   bool Development = false;
   bool flagInitState = true;
 
-
   // main loop
   auto render = [&]() {
     if (flagInitState) {
-
       set_inital_config(config);
       flagInitState = false;
-
     }
     SetupImGuiStyle(false, 0.99f, config);
     ImGui::SetNextWindowPos({0.f, 0.f});
@@ -108,8 +105,6 @@ int main() {
       ImGui::PopStyleColor(3);
     }
     if (flagPaused) {
-      ImGui::SameLine();
-
       // Start/reset the measurement when the measurement is paused,
       // followed by a query as to whether the old data should be saved
       if (sampler.has_value()) {
@@ -160,14 +155,19 @@ int main() {
       ImGui::PopStyleColor();
     }
     ImGui::EndChild(); // end child "Buttonstripe"
-                       // ############################ Settings Menu
-                       // ############################ Settings Menu
-    static std::vector titles{
-        (std::string)englishLan.find(Key::Settings)->second + "###ID",
-        (std::string)germanLan.find(Key::Settings)->second + "###ID"};
+    // ############################ Settings Menu
     static int title = 0;
+    static std::vector<std::string> titles(2); // two languages
     if (open_settings) {
-      ImGui::OpenPopup(titles[title].c_str());
+      const auto EngItr = englishLan.find(Key::Settings);
+      const auto GrmItr = germanLan.find(Key::Settings);
+      // check returned value from find() and set titles 
+      if (EngItr != englishLan.end() && GrmItr != germanLan.end()) {
+        titles[0] = (std::string)EngItr->second + "###ID";
+        titles[1] = (std::string)GrmItr->second + "###ID";
+        ImGui::OpenPopup(titles[title].c_str());
+      } else
+        fmt::println("Settings values not found.");
       open_settings = false;
     }
     if (ImGui::BeginPopupModal(titles[title].c_str(), nullptr,

--- a/src/saves_popup.cpp
+++ b/src/saves_popup.cpp
@@ -2,7 +2,6 @@
 #include <sstream>
 #include <future>
 #include <charconv>
-#include <print> // testing purposes
 #include "popups.hpp"
 #include "look_up_saves.hpp"
 #include "imgui_stdlib.h"
@@ -15,8 +14,8 @@ static void save(const Omniscope::Id &device,
                  const std::vector<std::pair<double, double>> &values,
                  const fs::path &outFile, std::string allData, size_t &y_indx) {
 
-  allData += fmt::format("\nType: {}\nSerial: {}\nSamplyingRate: {}\n", device.type,
-                        device.serial, device.sampleRate);
+  allData += fmt::format("\nType: {}\nSerial: {}\nSamplyingRate: {}\n",
+                         device.type, device.serial, device.sampleRate);
   std::string fileContent;
   fileContent.resize_and_overwrite(
       // five bytes for each y_value, three for the number

--- a/src/saves_popup.cpp
+++ b/src/saves_popup.cpp
@@ -1,6 +1,7 @@
 #include <fstream>
 #include <sstream>
 #include <future>
+#include <charconv>
 #include "popups.hpp"
 #include "look_up_saves.hpp"
 #include "imgui_stdlib.h"

--- a/src/saves_popup.cpp
+++ b/src/saves_popup.cpp
@@ -13,19 +13,17 @@ namespace fs = std::filesystem;
 static void save(const Omniscope::Id &device,
                  const std::vector<std::pair<double, double>> &values,
                  const fs::path &outFile, std::string allData, size_t &y_indx) {
-
-  allData += fmt::format("\nType: {}\nSerial: {}\nSamplyingRate: {}\n",
+  allData += fmt::format(",Type: {},Serial: {},SamplyingRate: {}\n",
                          device.type, device.serial, device.sampleRate);
   std::string fileContent;
   fileContent.resize_and_overwrite(
       // five bytes for each y_value, three for the number
       // and two spaces as a separator between the numbers
-      values.size() * 5, [&values, &y_indx](char *begin, std::size_t) {
+      values.size() * 4, [&values, &y_indx](char *begin, std::size_t) {
         auto end = begin;
         for (; y_indx < values.size(); y_indx++) {
           end = std::to_chars(end, end + 3, values[y_indx].second).ptr;
-          *end++ = ' ';
-          *end++ = ' ';
+          *end++ = '\n';
         }
         return end - begin;
       });

--- a/src/saves_popup.cpp
+++ b/src/saves_popup.cpp
@@ -2,6 +2,7 @@
 #include <sstream>
 #include <future>
 #include <charconv>
+#include <print> // testing purposes
 #include "popups.hpp"
 #include "look_up_saves.hpp"
 #include "imgui_stdlib.h"

--- a/src/saves_popup.cpp
+++ b/src/saves_popup.cpp
@@ -17,8 +17,8 @@ static void save(const Omniscope::Id &device,
                          device.type, device.serial, device.sampleRate);
   std::string fileContent;
   fileContent.resize_and_overwrite(
-      // five bytes for each y_value, three for the number
-      // and two spaces as a separator between the numbers
+      // four bytes for each y_value, three for the number
+      // and one new line as a separator between the numbers
       values.size() * 4, [&values, &y_indx](char *begin, std::size_t) {
         auto end = begin;
         for (; y_indx < values.size(); y_indx++) {
@@ -97,7 +97,7 @@ void saves_popup(nlohmann::json const &config, nlohmann::json const &language,
   }
 
   static char scantype[255] = "";
-  static char vin[18] = "";
+  static char vin[19] = "";
   static char mileage[10] = "";
   std::string inputvin =
       getSubdirectoriesInFolder(language, "saves", scantype, vin, mileage);
@@ -226,7 +226,7 @@ void saves_popup(nlohmann::json const &config, nlohmann::json const &language,
   if (ImGui::Button(appLanguage[Key::Back])) {
     ImGui::CloseCurrentPopup();
   }
-  ImGui::SameLine(ImGui::GetWindowWidth() - 100.f); // offset from start x
+  ImGui::SameLine(ImGui::GetWindowWidth() * 0.75f); // offset from start x
 
   static std::future<void> future;
   static size_t y_indx; // used for the progress bar too

--- a/src/saves_popup.cpp
+++ b/src/saves_popup.cpp
@@ -1,5 +1,6 @@
 #include <fstream>
 #include <sstream>
+#include <future>
 #include "popups.hpp"
 #include "look_up_saves.hpp"
 #include "imgui_stdlib.h"
@@ -10,34 +11,36 @@ namespace fs = std::filesystem;
 
 static void save(const Omniscope::Id &device,
                  const std::vector<std::pair<double, double>> &values,
-                 fs::path const &outFile, std::string allData) {
+                 const fs::path &outFile, std::string allData, size_t &y_indx) {
 
-  std::string fileContent =
-      fmt::format("\n{}-{}\n", device.type, device.serial);
-
-  for (std::size_t i{}; i < values.size(); ++i) {
-    fileContent += fmt::format("{},", i);
-    if (values[i].second)
-      fileContent += fmt::format("{}\n", values[i].second);
-  }
-
+  allData += fmt::format("\n{}-{}\nSamplying rate is 100000\n", device.type,
+                         device.serial);
+  std::string fileContent;
+  fileContent.resize_and_overwrite(
+      // five bytes for each y_value, three for the number
+      // and two spaces as a separator between the numbers
+      values.size() * 5, [&values, &y_indx](char *begin, std::size_t) {
+        auto end = begin;
+        for (; y_indx < values.size(); y_indx++) {
+          end = std::to_chars(end, end + 3, values[y_indx].second).ptr;
+          *end++ = ' ';
+          *end++ = ' ';
+        }
+        return end - begin;
+      });
   // create a .csv file to write to it
-  std::fstream file{outFile};
-  file.open(outFile, std::ios::out | std::ios::app);
-
+  std::ofstream file(outFile, std::ios::app);
   if (!file.is_open()) {
     file.clear();
     fmt::print("Could not create {} for writing!\n", outFile.string());
     return;
   }
-
   fmt::print("Start saving {}.\n", outFile.string());
   file << allData << fileContent;
   file.flush();
   file.close();
   fmt::print("Finished saving.\n");
 }
-
 void saves_popup(nlohmann::json const &config, nlohmann::json const &language,
                  std::map<Omniscope::Id, std::vector<std::pair<double, double>>>
                      &captureData,
@@ -161,8 +164,8 @@ void saves_popup(nlohmann::json const &config, nlohmann::json const &language,
   }
   // ############# End popup
 
-  // create a .csv file name
-  auto makeFileName = [&](const std::string &name) {
+  // make a .csv file name
+  auto mkFileName = [&](const std::string &name) {
     now = std::chrono::system_clock::now();
     now_time_t = std::chrono::system_clock::to_time_t(now);
     now_tm = *std::gmtime(&now_time_t);
@@ -170,8 +173,8 @@ void saves_popup(nlohmann::json const &config, nlohmann::json const &language,
     return filename;
   };
 
-  // create a director (if not exists) and return a path to it
-  auto makeDirectory = [&](bool hasSelectedPath, std::string selectedPath,
+  // make a directory (if not exists) and return a path to it
+  auto mkdir = [&](bool hasSelectedPath, std::string selectedPath,
                            std::string second_folder, std::string outFile) {
     fs::path complete_path;
     auto first_folder = load_json<fs::path>(config, "scanfolder");
@@ -206,7 +209,7 @@ void saves_popup(nlohmann::json const &config, nlohmann::json const &language,
     return complete_path / outFile;
   };
 
-  if (const size_t checkedDvc_cnt = count_checked_devices()) {
+  if (const size_t checkedDvc_cnt = count_checked_devices()) 
     if (checkedDvc_cnt > 1) {
       ImGui::SameLine();
       ImGui::Dummy({200, 0});
@@ -218,15 +221,19 @@ void saves_popup(nlohmann::json const &config, nlohmann::json const &language,
       ImGui::PopStyleVar();
       ImGui::SetItemTooltip("Add another path");
     }
-}
 
   ImGui::Separator();
   ImGui::NewLine();
   if (ImGui::Button(appLanguage[Key::Back])) {
     ImGui::CloseCurrentPopup();
   }
-  ImGui::SameLine(ImGui::GetWindowWidth() -
-                  100); // Ändern Sie 100 entsprechend Ihrer Anforderungen
+  ImGui::SameLine(ImGui::GetWindowWidth() - 100.f); // offset from start x
+
+  static std::future<void> future;
+  static size_t y_indx; // used for the progress bar too
+  static size_t valuesSize;
+  static bool progress{false};
+
   if (ImGui::Button(appLanguage[Key::Save])) {
     flagDataNotSaved = false;
 
@@ -234,29 +241,42 @@ void saves_popup(nlohmann::json const &config, nlohmann::json const &language,
       fmt::println("captureData is empty");
       ImGui::CloseCurrentPopup();
     }
-    fs::path complete_path;
 
-    size_t i{0};
-    for (const auto &[device, values] : captureData) {
+    fs::path path;
+    for (size_t i{}; const auto &[device, values] : captureData) {
       if (dvcCheckedArr[i].b) {
-        std::stringstream ss;
-        ss << "device" << i + 1;
-        auto filename = makeFileName(ss.str());
+        auto filename = mkFileName(std::format("device{}", i + 1).c_str());
         if (hasSelectedPathArr[i].b) {
-          complete_path = makeDirectory(true, selectedPathArr[i], "", filename);
-          save(device, values, complete_path, allData);
+          path = mkdir(true, selectedPathArr[i], "", filename);
           hasSelectedPathArr[i].b = false;
         } else if (!inptTxtFields[i].empty()) {
-          complete_path = makeDirectory(false, "", inptTxtFields[i], filename);
-          save(device, values, complete_path, allData);
+          path = mkdir(false, "", inptTxtFields[i], filename);
           inptTxtFields[i].clear();
-        } else {
-          complete_path = makeDirectory(false, "", "", filename);
-          save(device, values, complete_path, allData);
-        }
+        } else
+          path = mkdir(false, "", "", filename);
+        valuesSize = values.size();
+        future = std::async(std::launch::async, [&, path] {
+          save(device, values, path, allData, y_indx);
+        });
+        progress = true;
       }
-      ++i;
+      i++;
     }
-    ImGui::CloseCurrentPopup();
   }
+    if (progress) {
+      auto status = future.wait_for(std::chrono::milliseconds{1});
+      if (status == std::future_status::ready && future.valid()) {
+        future.get();
+        // reset related stuff
+        y_indx = 0;
+        valuesSize = 0;
+        progress = false;
+        inptTxtFields[0].clear(); // reset storage location after each save
+        ImGui::CloseCurrentPopup();
+      } else { 
+        ImGui::ProgressBar((float)y_indx / valuesSize, {0.f, 0.f});
+        ImGui::SameLine();
+        ImGui::Text(appLanguage[Key::saving]);
+      }
+    }
 }

--- a/src/saves_popup.cpp
+++ b/src/saves_popup.cpp
@@ -2,7 +2,6 @@
 #include <sstream>
 #include <future>
 #include <charconv>
-#include <format>
 #include "popups.hpp"
 #include "look_up_saves.hpp"
 #include "imgui_stdlib.h"
@@ -15,8 +14,8 @@ static void save(const Omniscope::Id &device,
                  const std::vector<std::pair<double, double>> &values,
                  const fs::path &outFile, std::string allData, size_t &y_indx) {
 
-  allData += fmt::format("\n{}-{}\nSamplying rate is 100000\n", device.type,
-                         device.serial);
+  allData += fmt::format("\nType: {}\nSerial: {}\nSamplyingRate: {}\n", device.type,
+                        device.serial, device.sampleRate);
   std::string fileContent;
   fileContent.resize_and_overwrite(
       // five bytes for each y_value, three for the number
@@ -247,7 +246,7 @@ void saves_popup(nlohmann::json const &config, nlohmann::json const &language,
     fs::path path;
     for (size_t i{}; const auto &[device, values] : captureData) {
       if (dvcCheckedArr[i].b) {
-        auto filename = mkFileName(std::format("device{}", i + 1).c_str());
+        auto filename = mkFileName(fmt::format("device{}", i + 1).c_str());
         if (hasSelectedPathArr[i].b) {
           path = mkdir(true, selectedPathArr[i], "", filename);
           hasSelectedPathArr[i].b = false;
@@ -278,7 +277,7 @@ void saves_popup(nlohmann::json const &config, nlohmann::json const &language,
       } else { 
         ImGui::ProgressBar((float)y_indx / valuesSize, {0.f, 0.f});
         ImGui::SameLine();
-        ImGui::Text(appLanguage[Key::saving]);
+        ImGui::Text(appLanguage[Key::Saving]);
       }
     }
 }

--- a/src/saves_popup.cpp
+++ b/src/saves_popup.cpp
@@ -2,6 +2,7 @@
 #include <sstream>
 #include <future>
 #include <charconv>
+#include <format>
 #include "popups.hpp"
 #include "look_up_saves.hpp"
 #include "imgui_stdlib.h"

--- a/src/settingspopup.hpp
+++ b/src/settingspopup.hpp
@@ -1,12 +1,12 @@
 #ifndef SETTINGS_H
 #define SETTINGS_H
 
-#include "jasonhandler.hpp"
-#include "languages.hpp"
-#include <fmt/format.h>
 #include <imgui.h>
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
+#include <fmt/format.h>
+#include "jasonhandler.hpp"
+#include "languages.hpp"
 
 static void popup_settings(nlohmann::json &config, nlohmann::json &language,
                            std::string const &configpath, int &title) {

--- a/src/settingspopup.hpp
+++ b/src/settingspopup.hpp
@@ -8,7 +8,7 @@
 #include "jasonhandler.hpp"
 #include "languages.hpp"
 
-static void popup_settings(nlohmann::json &config, nlohmann::json &language,
+static void popup_settings(nlohmann::json &config,
                            std::string const &configpath, int &title) {
 
   static float tempfontscale = config["text"]["scale"];


### PR DESCRIPTION
- improved saving process performance a lot
- implemented a progress bar in order to observe the process 
- fixed [the issue](https://support.microsoft.com/en-us/office/what-to-do-if-a-data-set-is-too-large-for-the-excel-grid-976e6a34-9756-48f4-828c-ca80b3d0e15c?ns=excel&version=21&syslcid=1033&uilcid=1033&appver=zxl210&helpid=xlmain11.chm655696&ui=en-us&rs=en-us&ad=us) of storing a great deal of data into a `.csv` file not to lose any data 
- code clean-up and enhancements 

Here's a test for a half an hour measurement with more than180 million y values. It took 9 seconds for saving on my machine: 

![Untitled](https://github.com/skunkforce/OmniView/assets/53223982/9b61359e-d514-431f-827d-75e47d94bceb)
