### PR TITLE
149 id in settingsmenu

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -1,4 +1,5 @@
 {
+    "Costumer_id": "kljhkhasdkf",
     "api": {
         "header1": "Content-Type: multipart/form-data",
         "header2": "Accept: application/json",
@@ -96,7 +97,7 @@
     },
     "scanfolder": "saves",
     "text": {
-        "active_language": "German",
+        "active_language": "English",
         "color": {
             "inactive": {
                 "blue": 0.5,
@@ -113,10 +114,9 @@
         },
         "font": "comicsans",
         "minscale": 1.0,
-        "scale": 1.5000001192092896
+        "scale": 2.200000047683716
     },
     "title": "Omniview 0.5",
-    "Costumer_id": "",
     "window": {
         "color": {
             "blue": 0.7,

--- a/config/config.json
+++ b/config/config.json
@@ -115,6 +115,7 @@
         "scale": 1.2
     },
     "title": "Omniview 0.5",
+    "Costumer_id": "",
     "window": {
         "color": {
             "blue": 0.7,

--- a/src/languages.hpp
+++ b/src/languages.hpp
@@ -68,7 +68,8 @@ enum class Key {
   Browse,
   Battery_measure,
   Attitude,
-  German
+  German,
+  Costumer_id
 };
 
 inline const std::map<Key, const char *> englishLan{
@@ -135,7 +136,8 @@ inline const std::map<Key, const char *> englishLan{
     {Key::Browse, "Browse"},
     {Key::Battery_measure, "Battery measurement"},
     {Key::Attitude, "Attitude"},
-    {Key::German, "German"}};
+    {Key::German, "German"},
+    {Key::Costumer_id, "Costumer ID"}};
 
 inline const std::map<Key, const char *> germanLan{
     {Key::Menu, "Menü"},
@@ -201,7 +203,8 @@ inline const std::map<Key, const char *> germanLan{
     {Key::Browse, "Durchsuche"},
     {Key::Battery_measure, "Batteriemessung"},
     {Key::Attitude, "Einstellung"},
-    {Key::German, "Deutch"}};
+    {Key::German, "Deutch"},
+    {Key::Costumer_id, "Benutzer ID"}};
 
 inline auto appLanguage = englishLan;
 #endif

--- a/src/languages.hpp
+++ b/src/languages.hpp
@@ -159,7 +159,6 @@ inline const std::map<Key, const char *> englishLan{
     {Key::FontSize, "Fontsize"},
     {Key::SettingsText, "Set your personal settings for the software"}};
 
-
 inline const std::map<Key, const char *> germanLan{
     {Key::Known_Car, "Fahrzeugauswahl"},
     {Key::New_Car, "Neues Fahrzeug"},

--- a/src/settingspopup.hpp
+++ b/src/settingspopup.hpp
@@ -9,7 +9,7 @@
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
 
-static void popup_settings(nlohmann::json &config, nlohmann::json &language,
+static void popup_settings(nlohmann::json &config,
                            std::string const &configpath, int &title) {
 
   static float tempfontscale = config["text"]["scale"];

--- a/src/settingspopup.hpp
+++ b/src/settingspopup.hpp
@@ -5,9 +5,9 @@
 #include "languages.hpp"
 #include <fmt/format.h>
 #include <imgui.h>
+#include <imgui_stdlib.h>
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
-#include <imgui_stdlib.h>
 
 static void popup_settings(nlohmann::json &config, nlohmann::json &language,
                            std::string const &configpath, int &title) {
@@ -21,16 +21,46 @@ static void popup_settings(nlohmann::json &config, nlohmann::json &language,
   ImGui::Text(appLanguage[Key::SettingsText]);
   ImGui::Text("                            ");
 
-  //create id and save in config (works but old id doesnt load)
-  //static char Costumer_id[20]= "";
-  //ImGui::InputText(fmt::format("{}", appLanguage[Key::Costumer_id]).c_str(),Costumer_id, sizeof(Costumer_id));
-  //newconfig["Costumer_id"]= Costumer_id;
-                  //for comparison:     //load_json<std::string>(language, "settings", "buttonexplain").c_str()
-  //new idea: load id from config file
-  //std::string KnownCostumer_id = load_json<std::string>(config, "Costumer_id");
-  //ImGui::InputText(fmt::format("{}", appLanguage[Key::Costumer_id]).c_str(), &KnownCostumer_id);
-  //newconfig["Costumer_id"]= KnownCostumer_id;
-//error: key not found initially in config, does not save when closed
+  // Create and initialize customer_id variable
+  static char customer_id[20] = "";
+
+  static bool is_initialized =
+      false; // Track if customer_id has been initialized
+
+  static bool isempty = false;
+
+  // Initialize customer_id only once
+  if (!is_initialized) {
+    std::string temp = config["Costumer_id"].get<std::string>();
+    std::copy(temp.begin(), temp.end(), customer_id);
+    if (temp.empty()) {
+      isempty = true;
+    }
+    customer_id[temp.size()] = '\0'; // Ensure null termination
+    is_initialized = true;
+  }
+
+  if (isempty) {
+    // If customer_id is an empty string, allow user to enter a new ID
+    ImGui::InputText(fmt::format("{}", appLanguage[Key::Costumer_id]).c_str(),
+                     customer_id, sizeof(customer_id));
+  } else {
+    // If customer_id is not empty, display it as a non-editable field
+    ImGui::Text(
+        fmt::format("{}: {}", appLanguage[Key::Costumer_id], customer_id)
+            .c_str());
+  }
+
+  // Save the potentially updated customer_id back to newconfig
+  newconfig["Costumer_id"] = std::string(customer_id);
+  // for comparison:     //load_json<std::string>(language, "settings",
+  // "buttonexplain").c_str()
+  // new idea: load id from config file
+  // std::string KnownCostumer_id = load_json<std::string>(config,
+  // "Costumer_id"); ImGui::InputText(fmt::format("{}",
+  // appLanguage[Key::Costumer_id]).c_str(), &KnownCostumer_id);
+  // newconfig["Costumer_id"]= KnownCostumer_id;
+  // error: key not found initially in config, does not save when closed
 
   if (tempfontscale < load_json<float>(config, "text", "minscale")) {
     tempfontscale = load_json<float>(config, "text", "minscale");
@@ -77,6 +107,7 @@ static void popup_settings(nlohmann::json &config, nlohmann::json &language,
     newconfig["text"]["scale"] = tempfontscale;
     newconfig["text"]["active_language"] =
         appLanguage == germanLan ? "German" : "English";
+    newconfig["Costumer_id"] = std::string(customer_id);
     config = newconfig;
     write_json_file(configpath, config);
     tempLan = appLanguage;

--- a/src/settingspopup.hpp
+++ b/src/settingspopup.hpp
@@ -1,15 +1,15 @@
 #ifndef SETTINGS_H
 #define SETTINGS_H
 
+#include "jasonhandler.hpp"
+#include "languages.hpp"
+#include <fmt/format.h>
 #include <imgui.h>
 #include <imgui_stdlib.h>
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
-#include <fmt/format.h>
-#include "jasonhandler.hpp"
-#include "languages.hpp"
 
-static void popup_settings(nlohmann::json &config,
+static void popup_settings(nlohmann::json &config, nlohmann::json &language,
                            std::string const &configpath, int &title) {
 
   static float tempfontscale = config["text"]["scale"];

--- a/src/settingspopup.hpp
+++ b/src/settingspopup.hpp
@@ -5,6 +5,7 @@
 #include <imgui.h>
 #include <nlohmann/json.hpp>
 #include <nlohmann/json_fwd.hpp>
+#include <imgui_stdlib.h>
 
 static void popup_settings(nlohmann::json &config, nlohmann::json &language,
                            std::string const &configpath) {
@@ -16,6 +17,17 @@ static void popup_settings(nlohmann::json &config, nlohmann::json &language,
   if (fontscale < load_json<float>(newconfig, "text", "minscale")) {
     fontscale = load_json<float>(newconfig, "text", "minscale");
   }
+  //create id and save in config (works but old id doesnt load)
+  //static char Costumer_id[20]= "";
+  //ImGui::InputText(fmt::format("{}", appLanguage[Key::Costumer_id]).c_str(),Costumer_id, sizeof(Costumer_id));
+  //newconfig["Costumer_id"]= Costumer_id;
+                  //for comparison:     //load_json<std::string>(language, "settings", "buttonexplain").c_str()
+  //new idea: load id from config file
+  //std::string KnownCostumer_id = load_json<std::string>(config, "Costumer_id");
+  //ImGui::InputText(fmt::format("{}", appLanguage[Key::Costumer_id]).c_str(), &KnownCostumer_id);
+  //newconfig["Costumer_id"]= KnownCostumer_id;
+//error: key not found initially in config, does not save when closed
+
   ImGuiIO &io = ImGui::GetIO();
   io.FontGlobalScale = fontscale;
   std::string fontscalestring = fmt::format(


### PR DESCRIPTION
To compile, you have to use the config that is in the branch, make sure the key-value pair  `"Customer_Id": ""` exists and set the path to this config in the settingspopup.hpp. In the master version, the key-value pair `"Customer_Id": ""` needs to be added.