### PR TITLE
bug fixing and improvements

### DIFF
--- a/src/saves_popup.cpp
+++ b/src/saves_popup.cpp
@@ -216,7 +216,7 @@ void saves_popup(nlohmann::json const &config, nlohmann::json const &language,
 
   ImGui::Separator();
   ImGui::NewLine();
-  if (ImGui::Button(appLanguage[Key::Back]))
+  if (ImGui::Button(appLanguage[Key::Back])) 
     ImGui::CloseCurrentPopup();
   ImGui::SameLine(ImGui::GetWindowWidth() * 0.75f); // offset from start x
 
@@ -229,9 +229,10 @@ void saves_popup(nlohmann::json const &config, nlohmann::json const &language,
   if (ImGui::Button(appLanguage[Key::Save])) {
     checked_devices_cnt = count_checked_devices();
     flagDataNotSaved = false;
-    future = std::async(       // const reference to the conatainer 
+    future = std::async(       // const reference to the container 
         std::launch::async, [=, &liveDvcs = std::as_const(liveDvcs)] {
           for (size_t i{}; const auto &[device, values] : liveDvcs) {
+            // measurement saving preparation if device is checked
             if (dvcCheckedArr[i].b) {
               fs::path path;
               auto filename = mkFileName(fmt::format("device{}", i + 1));
@@ -244,6 +245,7 @@ void saves_popup(nlohmann::json const &config, nlohmann::json const &language,
               } else
                 path = mkdir(false, "", "", filename);
               valuesSize = values.size();
+              // save measurement of each device in a separate file
               save(device, values, path, allData, y_indx, filename,
                    saved_files_cnt);
             }

--- a/src/saves_popup.cpp
+++ b/src/saves_popup.cpp
@@ -229,8 +229,8 @@ void saves_popup(nlohmann::json const &config, nlohmann::json const &language,
   if (ImGui::Button(appLanguage[Key::Save])) {
     checked_devices_cnt = count_checked_devices();
     flagDataNotSaved = false;
-    future =
-        std::async(std::launch::async, [=] {
+    future = std::async(       // const reference to the conatainer 
+        std::launch::async, [=, &liveDvcs = std::as_const(liveDvcs)] {
           for (size_t i{}; const auto &[device, values] : liveDvcs) {
             if (dvcCheckedArr[i].b) {
               fs::path path;
@@ -256,7 +256,8 @@ void saves_popup(nlohmann::json const &config, nlohmann::json const &language,
     if (saved_files_cnt == checked_devices_cnt) {
       future.get();
       progress = false;
-      inptTxtFields.clear(); // reset storage location(s) after save
+      inptTxtFields.clear(); // reset storage location(s) 
+      dvcCheckedArr.clear(); // rest check boxes
       saved_files_cnt = 0;
       ImGui::CloseCurrentPopup();
     } else {

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -360,6 +360,7 @@ void set_toolbar(const nlohmann::json &config, const nlohmann::json &language,
   auto windowSize{ImGui::GetIO().DisplaySize};
   static bool flagDataNotSaved = true;
   static decltype(captureData) liveDvcs;
+  static bool has_loaded_file;
 
   // begin Toolbar ############################################
   ImGui::BeginChild("Buttonstripe", {-1.f, windowSize.y * .1f}, false,
@@ -369,7 +370,7 @@ void set_toolbar(const nlohmann::json &config, const nlohmann::json &language,
                              ImGuiWindowFlags_AlwaysAutoResize)) {
     ImGui::SetItemDefaultFocus();
     saves_popup(config, language, now, now_time_t, now_tm, flagDataNotSaved,
-                liveDvcs);
+                has_loaded_file ? liveDvcs : captureData);
     ImGui::EndPopup();
   }
   // ############################ Popup Reset
@@ -497,9 +498,14 @@ void set_toolbar(const nlohmann::json &config, const nlohmann::json &language,
                            (void *)(intptr_t)image_texture[PngRenderedCnt],
                            ImVec2(image_width[PngRenderedCnt] * iconsSacle,
                                   image_height[PngRenderedCnt] * iconsSacle))) {
-      for (const auto &[device, values] : captureData)
-        if (!loadedFiles.contains(device))
-          liveDvcs.emplace(device, values); // extract live devices (the little overhead)
+      if (!loadedFiles.empty()) { 
+        has_loaded_file = true;
+        for (const auto &[device, values] : captureData)
+          if (!loadedFiles.contains(device))
+            liveDvcs.emplace(
+                device, values); // extract live devices (the little overhead)
+      } else
+        has_loaded_file = false;
 
       if (sampler.has_value())
         ImGui::OpenPopup(appLanguage[Key::Save_Recorded_Data]);

--- a/src/style.cpp
+++ b/src/style.cpp
@@ -498,6 +498,7 @@ void set_toolbar(const nlohmann::json &config, const nlohmann::json &language,
                            (void *)(intptr_t)image_texture[PngRenderedCnt],
                            ImVec2(image_width[PngRenderedCnt] * iconsSacle,
                                   image_height[PngRenderedCnt] * iconsSacle))) {
+      liveDvcs.clear(); // get updated live devices for saving 
       if (!loadedFiles.empty()) { 
         has_loaded_file = true;
         for (const auto &[device, values] : captureData)


### PR DESCRIPTION
- improved the code to save measurements for all connected devices
- rather than only doing one async task at a time, launched a single thread that does all the work more efficiently
- used `std::atomic` to make variables thread-safe
- live devices data extraction is done only when there is/are some file(s) loaded 
- code cleanup 

It's expected that you have, e.g., three saved files (one progress bar for each) containing related measurement data if you connect 3 devices and measure data using them